### PR TITLE
Don't save the context_key and the area in updatefromgrid processor.

### DIFF
--- a/core/components/crosscontextssettings/processors/mgr/settings/updatefromgrid.class.php
+++ b/core/components/crosscontextssettings/processors/mgr/settings/updatefromgrid.class.php
@@ -51,7 +51,9 @@ class SettingUpdateFromGridProcessor extends modObjectProcessor {
             if ($k === 'key' ||
                     $k === 'action' ||
                     $k === 'menu' ||
-                    $k === 'xtype'
+                    $k === 'xtype'  || 
+                    $k === 'context_key'  || 
+                    $k === 'area'
             ) {
                 continue;
             }


### PR DESCRIPTION
Don't save the context_key and the area in updatefromgrid processor.